### PR TITLE
Added a vararg variant of the `group` function

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 val groupId = "com.theonlytails"
-val libVersion = "0.1.5"
+val libVersion = "0.1.6"
 
 group = groupId
 version = libVersion

--- a/src/main/kotlin/com/theonlytails/ketex/groups.kt
+++ b/src/main/kotlin/com/theonlytails/ketex/groups.kt
@@ -78,9 +78,33 @@ class KetexGroup(private val type: KetexGroupType, private val name: String) : K
 }
 
 context(KetexFragment)
-        @KetexMarker
-        inline fun group(
+@KetexMarker
+inline fun group(
     type: KetexGroupType = KetexGroupType.Capture,
     name: String = "",
     block: KetexGroup.() -> Unit,
 ) = KetexGroup(type, name).apply(block)
+
+context(KetexFragment)
+@KetexMarker
+fun group(vararg tokens: String) = group {
+    tokens.forEach { +it }
+}
+
+context(KetexFragment)
+@KetexMarker
+fun group(vararg tokens: Char) = group {
+    tokens.forEach { +it }
+}
+
+context(KetexFragment)
+@KetexMarker
+fun group(vararg tokens: CharRange) = group {
+    tokens.forEach { +it }
+}
+
+context(KetexFragment)
+@KetexMarker
+fun group(vararg tokens: KetexToken) = group {
+    tokens.forEach { +it }
+}

--- a/src/test/kotlin/KetexTest.kt
+++ b/src/test/kotlin/KetexTest.kt
@@ -325,4 +325,13 @@ class KetexTest {
             }
         )
     }
+
+    @Test
+    fun `group with vararg`() {
+        assertEquals("""(abc)""",
+            regexAsString {
+                +group("abc")
+            }
+        )
+    }
 }


### PR DESCRIPTION
Adds a version of the group function which receives its tokens directly and adds them (instead of the builder DSL).